### PR TITLE
[fastlane] add changelogs

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/1.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1.txt
@@ -1,0 +1,4 @@
+v1.0
+ 1. Implemented VPN network interface for Yggdrasil tunneling
+ 2. Optimized memory buffer
+ 3. Added IPv6 info

--- a/fastlane/metadata/android/en-US/changelogs/2.txt
+++ b/fastlane/metadata/android/en-US/changelogs/2.txt
@@ -1,0 +1,13 @@
+v1.2
+ * New DNS and new Peer form
+ * fix adding Peers when json url unavailable
+ * DNS dynamic list selection fixes
+ * ping selected Peers and DNS fixes
+ * fixed when app crashed sometimes after ygg switch off
+ * fixed high CPU consumption after switch-off.
+ * prevent NPE fix
+
+v1.1
+ 1. Added dynamic peer list loading and edit functionality
+ 2. Layout minor changes
+ 3. Peers ping test and sorting by response time

--- a/fastlane/metadata/android/en-US/changelogs/3.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3.txt
@@ -1,0 +1,3 @@
+v1.3
+ 1. open MainActivity after Notification click, task (#12)
+ 2. new DNS only number issue


### PR DESCRIPTION
finaly fond releases on your fork ... so here they are

since v1.1 and v1.2 have the **same** versionCode -> F-Droid can only build one of the versions ... 

source: https://github.com/vikulin/yggdrasil-android/releases